### PR TITLE
Add go.mod support and fix undef errors.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/scottjbarr/sqsmv
+
+require github.com/aws/aws-sdk-go v1.15.71

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+github.com/aws/aws-sdk-go v1.15.71 h1:uHSetqgErh6XOVupwkmuZulOynAbvMdkBoMHIMLwuVs=
+github.com/aws/aws-sdk-go v1.15.71/go.mod h1:E3/ieXAlvM0XWO57iftYVDLLvQ824smPP3ATZkfNZeM=
+github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8 h1:12VvqtR6Aowv3l/EQUlocDHW2Cp4G9WJVH7uyH8QFJE=
+github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=

--- a/main.go
+++ b/main.go
@@ -16,6 +16,10 @@ func main() {
 	dest := flag.String("dest", "", "destination queue")
 	srcRegion := flag.String("srcRegion", "", "source region")
 	destRegion := flag.String("destRegion", "", "destination region")
+
+	var clientSrc *sqs.SQS
+	var clientDest *sqs.SQS
+
 	flag.Parse()
 
 	if *src == "" || *dest == "" {
@@ -47,15 +51,15 @@ func main() {
 	}
 
 	if *srcRegion == "" {
-		clientSrc := sqs.New(sessionSrc)
+		clientSrc = sqs.New(sessionSrc)
 	} else {
-		clientSrc := sqs.New(sessionSrc, aws.NewConfig().WithRegion(srcRegion))
+		clientSrc = sqs.New(sessionSrc, aws.NewConfig().WithRegion(*srcRegion))
 	}
 
 	if *destRegion == "" {
-		clientDest := sqs.New(sessionDst)
+		clientDest = sqs.New(sessionDst)
 	} else {
-		clientDest := sqs.New(sessionDst, aws.NewConfig().WithRegion(destRegion))
+		clientDest = sqs.New(sessionDst, aws.NewConfig().WithRegion(*destRegion))
 	}
 
 	maxMessages := int64(10)


### PR DESCRIPTION
Can now run in any directory as long as you have go 1.10+ by just: `go run main.go <args>`